### PR TITLE
Python 2: Fix sys.stdout.buffer.write()

### DIFF
--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -46,8 +46,15 @@ def cmd(args):
     if retcode:
         raise subprocess.CalledProcessError(retcode, args, output=out)
 
-    sys.stdout.buffer.write(out)
-    sys.stderr.buffer.write(err)
+    if sys.version_info >= (3,):
+        sys.stdout.buffer.write(out)
+        sys.stderr.buffer.write(err)
+    else:
+        # Python 2 doesn't have a .buffer on stdout/stderr for writing binary
+        # data. The below will only work for unicode in Python 2.7.1+ due to
+        # https://bugs.python.org/issue4947.
+        sys.stdout.write(out)
+        sys.stderr.write(err)
 
 
 class DockerCiDeployRunner(object):

--- a/docker_ci_deploy/tests/test_main.py
+++ b/docker_ci_deploy/tests/test_main.py
@@ -69,6 +69,12 @@ def test_strip_image_tag_unparsable():
 
 def assert_output_lines(capfd, stdout_lines, stderr_lines=[]):
     out, err = capfd.readouterr()
+    if sys.version_info < (3,):
+        # FIXME: I'm not entirely sure how to determine the correct encoding
+        # here and not sure whether the right answer comes from Python itself
+        # or pytest. For now, UTF-8 seems like a safe bet.
+        out = out.encode('utf-8')
+        err = err.encode('utf-8')
 
     out_lines = out.split('\n')
     assert out_lines.pop() == ''
@@ -98,6 +104,16 @@ def test_cmd_stderr(capfd):
     cmd(['awk', 'BEGIN { print "Hello, World!" > "/dev/stderr" }'])
 
     assert_output_lines(capfd, stdout_lines=[], stderr_lines=['Hello, World!'])
+
+
+def test_cmd_stdout_unicode(capfd):
+    """
+    When a command writes Unicode to a standard stream, that output should be
+    captured and encoded correctly.
+    """
+    cmd(['echo', 'á, é, í, ó, ú, ü, ñ, ¿, ¡'])
+
+    assert_output_lines(capfd, ['á, é, í, ó, ú, ü, ñ, ¿, ¡'])
 
 
 def test_cmd_error(capfd):


### PR DESCRIPTION
Tests were passing because of pytest's overwriting of `sys.stdout`/`sys.stderr`. Seemed to be replacing it with something that looked more Python 3 like and had `.buffer`.

Just use `sys.stdout/err.write()` for Python 2.