### PR TITLE
No long description or README in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ addopts = --capture=fd
 
 [bdist_wheel]
 universal=1
-
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup, find_packages
 
+
+with open('README.md') as f:
+    README = f.read()
+
 setup(
     name='docker-ci-deploy',
     version='0.1.2-dev',
@@ -7,6 +11,7 @@ setup(
     url='https://github.com/praekeltfoundation/docker-ci-deploy',
     description='Python script to help push Docker images to a registry using '
                 'CI services',
+    long_description=README,
     author='Jamie Hewland',
     author_email='jamie@praekelt.com',
     classifiers=[


### PR DESCRIPTION
The `[metadata]` field in `setup.cfg` doesn't actually seem to do anything (suspect it's overwritten by `description` param in `setup.py`). See more [here](http://alexis.notmyidea.org/distutils2/setupcfg.html#metadata).

Two solutions/workarounds I can think of
* Consider just reading `README.md` in `setup.py` and setting `long_description` to the value of the contents.
* Rename `README.md` to `README` and hope Python picks it up as that is one of its standard names. Think Github accepts either name.