### PR TITLE
Add --tag-latest to tag with the 'latest' tag or a tag without a version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ In a single command, `docker-ci-deploy` can:
 * Login to a registry
 * Push tags to a registry
 
-The best way to try out `docker-ci-deploy` is to give it a spin with the `--dry-run` flag and observe all the :
+The best way to try out `docker-ci-deploy` is to give it a spin with the `--dry-run` flag and observe all the `docker` commands that it *would* invoke:
 ```
 > $ docker-ci-deploy --tag-version 2.7.13 --tag-latest \
-      --registry registry:5000 --login 'janedoe:pa55word' --dry-run \
+      --registry registry:5000 --login 'janedoe:pa$$word' --dry-run \
       praekeltorg/alpine-python \
       praekeltorg/alpine-python:onbuild
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,32 @@
 [![Build Status](https://travis-ci.org/praekeltfoundation/docker-ci-deploy.svg?branch=develop)](https://travis-ci.org/praekeltfoundation/docker-ci-deploy)
 [![codecov](https://codecov.io/gh/praekeltfoundation/docker-ci-deploy/branch/develop/graph/badge.svg)](https://codecov.io/gh/praekeltfoundation/docker-ci-deploy)
 
-Python script to help push Docker images to a registry using CI services
+A command-line tool to help generate tags and push Docker images to a registry. Simplifies deployment of Docker images from CI services such as Travis CI.
+
+In a single command, `docker-ci-deploy` can:
+* Change the tags on images
+* Add version information to image tags
+* Add registry addresses to image tags
+* Login to a registry
+* Push tags to a registry
+
+The best way to try out `docker-ci-deploy` is to give it a spin with the `--dry-run` flag and observe all the :
+```
+> $ docker-ci-deploy --tag-version 2.7.13 --tag-latest \
+      --registry registry:5000 --login 'janedoe:pa55word' --dry-run \
+      praekeltorg/alpine-python \
+      praekeltorg/alpine-python:onbuild
+
+docker tag praekeltorg/alpine-python registry:5000/praekeltorg/alpine-python:2.7.13
+docker tag praekeltorg/alpine-python registry:5000/praekeltorg/alpine-python:latest
+docker tag praekeltorg/alpine-python:onbuild registry:5000/praekeltorg/alpine-python:2.7.13-onbuild
+docker tag praekeltorg/alpine-python:onbuild registry:5000/praekeltorg/alpine-python:onbuild
+docker login --username janedoe --password <password> registry:5000
+docker push registry:5000/praekeltorg/alpine-python:2.7.13
+docker push registry:5000/praekeltorg/alpine-python:latest
+docker push registry:5000/praekeltorg/alpine-python:2.7.13-onbuild
+docker push registry:5000/praekeltorg/alpine-python:onbuild
+```
 
 ## Installation
 ```
@@ -46,6 +71,12 @@ docker-ci-deploy --login 'janedoe:pa$$word' \
   --tag alpine --tag-version 1.2.3 my-image
 ```
 This will result in the tag `my-image:1.2.3-alpine` being created and pushed. If a version is already present in the start of a tag, it will not be added. For example, in the above example if `--tag 1.2.3-alpine` were provided, the image would still be tagged with `1.2.3-alpine`, not `1.2.3-1.2.3-alpine`.
+
+You can also push the tags without the version information so that they are considered the "latest" tag:
+```
+docker-ci-deploy --tag-version 1.2.3 --tag-latest my-image
+```
+This will result in the tags `my-image:1.2.3` and `my-image:latest` being pushed.
 
 #### Custom registry
 ```

--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -109,7 +109,7 @@ def generate_versioned_tags(tag, version, latest=False):
         tag(s). Include the tag 'latest' if the given tag is empty or None.
     :rtype: list
     """
-    if version is None:
+    if not version:
         return [tag]
 
     stripped_tag = _strip_tag_version(tag, version)
@@ -245,7 +245,7 @@ class DockerCiDeployRunner(object):
         :param registry:
             The address to the Docker registry host.
         """
-        if latest and version is None:
+        if latest and not version:
             raise ValueError('A version must be provided if latest is True')
 
         # Build map of images to tags to push with provided tags
@@ -326,7 +326,7 @@ def main(raw_args=sys.argv[1:]):
     args = parser.parse_args(raw_args)
 
     # --tag-latest requires --tag-version
-    if args.tag_latest and args.tag_version is None:
+    if args.tag_latest and not args.tag_version:
         parser.error('the --tag-latest option requires --tag-version')
 
     runner = DockerCiDeployRunner(dry_run=args.dry_run, verbose=args.verbose,

--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -257,15 +257,15 @@ class DockerCiDeployRunner(object):
             new_image = replace_image_registry(image, registry)
 
             # Add the version to any tags
-            tags = tags if tags is not None else [tag]
-            new_tags = []
-            for new_tag in tags:
-                new_tags.extend(
+            new_tags = tags if tags is not None else [tag]
+            version_tags = []
+            for new_tag in new_tags:
+                version_tags.extend(
                     generate_versioned_tags(new_tag, version, latest))
 
             # Finally, rejoin the image name and tag parts
-            new_image_tags = (
-                [join_image_tag(new_image, new_tag) for new_tag in new_tags])
+            new_image_tags = [join_image_tag(new_image, version_tag)
+                              for version_tag in version_tags]
 
             tag_map.append((image_tag, new_image_tags))
 

--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -139,9 +139,6 @@ def _join_tag_version(tag, version):
     Join a tag (not image tag) and version by prepending the version to the tag
     with a '-' character.
     """
-    if not tag:
-        return version
-
     return '-'.join((version, tag))
 
 

--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -299,8 +299,9 @@ def main(raw_args=sys.argv[1:]):
     parser.add_argument('--tag-version',
                         help='Prepend the given version to all tags')
     parser.add_argument('--tag-latest',
-                        help="Tag the image with the 'latest' tag or a tag "
-                             'without a version')
+                        help='Combine with --tag-version to also tag the '
+                             'image without a version so that it is considered'
+                             'the latest version')
     parser.add_argument('-l', '--login', nargs='?',
                         help='Login details in the form <username>:<password> '
                              'to login to the registry')

--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -95,7 +95,8 @@ def _join_image_registry(image, registry):
 def generate_versioned_tags(tag, version, latest=False):
     """
     Generate a list of tags based on the given tag and version information.
-    Prepends the given version
+    Prepends the given version to the tag, unless the version is already
+    present.
 
     :param tag:
         The input tag to generate version tags from. The tag 'latest' is

--- a/docker_ci_deploy/tests/test_main.py
+++ b/docker_ci_deploy/tests/test_main.py
@@ -11,7 +11,7 @@ from testtools.matchers import (
 
 from docker_ci_deploy.__main__ import (
     cmd, DockerCiDeployRunner, join_image_tag, main, replace_image_registry,
-    replace_tag_version, split_image_tag)
+    generate_versioned_tags, split_image_tag)
 
 
 class TestSplitImageTagFunc(object):
@@ -134,37 +134,74 @@ class TestReplaceImageRegistryFunc(object):
             replace_image_registry(image, 'registry:5000')
 
 
-class TestReplaceTagVersionFunc(object):
+class TestGenerateVersionedTagsFunc(object):
     def test_tag_without_version(self):
         """
         When a tag does not start with the version, the version should be
         prepended to the tag with a '-' character.
         """
-        tag = replace_tag_version('foo', '1.2.3')
-        assert_that(tag, Equals('1.2.3-foo'))
+        tags = generate_versioned_tags('foo', '1.2.3')
+        assert_that(tags, Equals(['1.2.3-foo']))
 
     def test_tag_with_version(self):
         """
         When a tag starts with the version, then the version and '-' separator
         should be removed from the tag and the remaining tag returned.
         """
-        tag = replace_tag_version('1.2.3-foo', '1.2.3')
-        assert_that(tag, Equals('1.2.3-foo'))
+        tags = generate_versioned_tags('1.2.3-foo', '1.2.3')
+        assert_that(tags, Equals(['1.2.3-foo']))
 
     def test_tag_is_version(self):
         """ When a tag is equal to the version, the tag should be returned. """
-        tag = replace_tag_version('1.2.3', '1.2.3')
-        assert_that(tag, Equals('1.2.3'))
+        tags = generate_versioned_tags('1.2.3', '1.2.3')
+        assert_that(tags, Equals(['1.2.3']))
 
     def test_tag_is_none(self):
         """ When a tag is None, the version should be returned. """
-        tag = replace_tag_version(None, '1.2.3')
-        assert_that(tag, Equals('1.2.3'))
+        tags = generate_versioned_tags(None, '1.2.3')
+        assert_that(tags, Equals(['1.2.3']))
+
+    def test_tag_is_latest(self):
+        """ When the tag is 'latest', the version should be returned. """
+        tags = generate_versioned_tags('latest', '1.2.3')
+        assert_that(tags, Equals(['1.2.3']))
 
     def test_version_is_none(self):
         """ When the version is None, the tag should be returned. """
-        tag = replace_tag_version('foo', None)
-        assert_that(tag, Equals('foo'))
+        tags = generate_versioned_tags('foo', None)
+        assert_that(tags, Equals(['foo']))
+
+    def test_latest(self):
+        """
+        When latest is True and a tag and version are provided, the versioned
+        and unversioned tags should be returned.
+        """
+        tags = generate_versioned_tags('foo', '1.2.3', latest=True)
+        assert_that(tags, Equals(['1.2.3-foo', 'foo']))
+
+    def test_latest_tag_is_latest(self):
+        """
+        When latest is True and a tag and version are provided, and the tag is
+        'latest', the versioned tag and 'latest' tag should be returned.
+        """
+        tags = generate_versioned_tags('latest', '1.2.3', latest=True)
+        assert_that(tags, Equals(['1.2.3', 'latest']))
+
+    def test_latest_version_is_none(self):
+        """
+        When latest is True and a tag and version are provided, and the version
+        is None, the the tag should be returned.
+        """
+        tags = generate_versioned_tags('foo', None, latest=True)
+        assert_that(tags, Equals(['foo']))
+
+    def test_latest_tag_and_version_are_none(self):
+        """
+        When latest is True and a tag and version are provided, and the tag and
+        version are None, 'latest' should be returned.
+        """
+        tags = generate_versioned_tags(None, None, latest=True)
+        assert_that(tags, Equals(['latest']))
 
 
 """ cmd() """
@@ -303,6 +340,15 @@ class TestDockerCiDeployRunner(object):
             'push test-image:def'
         ])
 
+    def test_tag_latest(self, capfd):
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], tags=['latest'])
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:latest',
+            'push test-image:latest'
+        ])
+
     def test_version_no_tag(self, capfd):
         """
         When a version is provided and there is no tag, the image should be
@@ -378,6 +424,221 @@ class TestDockerCiDeployRunner(object):
         assert_output_lines(capfd, [
             'tag test-image:abc test-image:1.2.3-def',
             'push test-image:1.2.3-def',
+        ])
+
+    # FIXME?: The following 2 tests describe a weird, unintuitive edge case :-(
+    # Passing `--tag latest` with `--tag-version <version>` but *not*
+    # `--tag-latest` doesn't actually get you the tag 'latest' but rather
+    # effectively removes any existing tag.
+    def test_version_new_tag_is_latest(self, capfd):
+        """
+        When a version is provided as well as a new tag, and the new tag is
+        'latest', then the image should be tagged with the new version only.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], tags=['latest'], version='1.2.3')
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3',
+            'push test-image:1.2.3',
+        ])
+
+    def test_version_new_tag_is_latest_with_version(self, capfd):
+        """
+        When a version is provided as well as a new tag, and the new tag is
+        'latest' plus the version, then the image should be tagged with the
+        new version only.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], tags=['1.2.3-latest'], version='1.2.3')
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3',
+            'push test-image:1.2.3',
+        ])
+
+    def test_latest_no_tag_no_version(self, capfd):
+        """
+        When latest is True and there is no tag or version, the image should be
+        tagged with 'latest'.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image'], latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image test-image:latest',
+            'push test-image:latest',
+        ])
+
+    def test_latest_existing_tag_no_version(self, capfd):
+        """
+        When latest is True and there is an existing tag but no version, the
+        image should not be retagged.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], latest=True)
+
+        assert_output_lines(capfd, [
+            'push test-image:abc',
+        ])
+
+    def test_latest_new_tag_is_latest_no_version(self, capfd):
+        """
+        When latest is True and the new tag is 'latest' but no version is
+        passed, the image should be tagged with the tag 'latest'.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], tags=['latest'], latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:latest',
+            'push test-image:latest',
+        ])
+
+    def test_latest_no_tag_with_version(self, capfd):
+        """
+        When latest is True and no tag is present but a version is, the image
+        should be tagged with the version and the 'latest' tag.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image'], version='1.2.3', latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image test-image:1.2.3',
+            'tag test-image test-image:latest',
+            'push test-image:1.2.3',
+            'push test-image:latest',
+        ])
+
+    def test_latest_with_existing_tag_and_version(self, capfd):
+        """
+        When latest is True and an existing tag is present as well as a
+        version, the image should be tagged with the version prepended to the
+        existing tag and both the new tag and existing tag should be pushed.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], version='1.2.3', latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3-abc',
+            'push test-image:1.2.3-abc',
+            'push test-image:abc',
+        ])
+
+    def test_latest_with_existing_version_tag_and_version(self, capfd):
+        """
+        When latest is True and an existing tag is present that is the same
+        provided version, the image should be tagged with the 'latest' tag and
+        both the versioned and 'latest' tags should be pushed.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:1.2.3'], version='1.2.3', latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:1.2.3 test-image:latest',
+            'push test-image:1.2.3',
+            'push test-image:latest',
+        ])
+
+    def test_latest_with_new_tag_no_version(self, capfd):
+        """
+        When latest is True and a new tag is provided but no version is
+        provided, the image should be tagged with the new tag.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], tags=['def'], latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:def',
+            'push test-image:def',
+        ])
+
+    def test_latest_with_new_tag_and_version(self, capfd):
+        """
+        When latest is True and a new tag and a version is provided, the image
+        should be tagged with the version prepended to the new tag and the new
+        tag by itself.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(
+            ['test-image:abc'], tags=['def'], version='1.2.3', latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3-def',
+            'tag test-image:abc test-image:def',
+            'push test-image:1.2.3-def',
+            'push test-image:def',
+        ])
+
+    def test_latest_with_new_tag_is_version(self, capfd):
+        """
+        When latest is True and a new tag is provided that is equal to the
+        version provided, the image should be tagged with the version and the
+        'latest' tag.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(
+            ['test-image:abc'], tags=['1.2.3'], version='1.2.3', latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3',
+            'tag test-image:abc test-image:latest',
+            'push test-image:1.2.3',
+            'push test-image:latest',
+        ])
+
+    def test_latest_with_new_tag_contains_version(self, capfd):
+        """
+        When latest is True and a new tag is provided that already contains the
+        version provided, the image should be tagged with the versioned tag and
+        the part of the tag without the version.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], tags=['1.2.3-def'], version='1.2.3',
+                   latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3-def',
+            'tag test-image:abc test-image:def',
+            'push test-image:1.2.3-def',
+            'push test-image:def',
+        ])
+
+    # FIXME?: The following 2 tests describe a weird, unintuitive edge case :-(
+    # It's impossible to get a tag of the form `<version>-latest`, even when
+    # passing `--tag latest`, `--tag-version <version>`, and `--tag-latest`.
+    def test_latest_with_new_tag_is_latest_and_version(self, capfd):
+        """
+        When latest is True and a new tag is provided that is 'latest' as well
+        as a version, the image should be tagged with the version and the
+        'latest' tag.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], tags=['latest'], version='1.2.3',
+                   latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3',
+            'tag test-image:abc test-image:latest',
+            'push test-image:1.2.3',
+            'push test-image:latest',
+        ])
+
+    def test_latest_with_new_tag_is_latest_and_contains_version(self, capfd):
+        """
+        When latest is True and a new tag is provided that is 'latest' and
+        contains the provided version, the image should be tagged with the
+        version and the 'latest' tag.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc'], tags=['1.2.3-latest'], version='1.2.3',
+                   latest=True)
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3',
+            'tag test-image:abc test-image:latest',
+            'push test-image:1.2.3',
+            'push test-image:latest',
         ])
 
     def test_registry(self, capfd):
@@ -469,13 +730,12 @@ class TestDockerCiDeployRunner(object):
                    login='janedoe:pa55word')
 
         assert_output_lines(capfd, [
-            ('tag test-image:tag '
-                'registry.example.com:5000/test-image:1.2.3-latest'),
+            'tag test-image:tag registry.example.com:5000/test-image:1.2.3',
             ('tag test-image:tag '
                 'registry.example.com:5000/test-image:1.2.3-best'),
             'login --username janedoe --password pa55word '
             'registry.example.com:5000',
-            'push registry.example.com:5000/test-image:1.2.3-latest',
+            'push registry.example.com:5000/test-image:1.2.3',
             'push registry.example.com:5000/test-image:1.2.3-best'
         ])
 
@@ -494,19 +754,17 @@ class TestDockerCiDeployRunner(object):
                    login='janedoe:pa55word')
 
         assert_output_lines(capfd, [
-            ('tag test-image:tag '
-                'registry.example.com:5000/test-image:1.2.3-latest'),
+            'tag test-image:tag registry.example.com:5000/test-image:1.2.3',
             ('tag test-image:tag '
                 'registry.example.com:5000/test-image:1.2.3-best'),
-            ('tag test-image2:tag2 '
-                'registry.example.com:5000/test-image2:1.2.3-latest'),
+            'tag test-image2:tag2 registry.example.com:5000/test-image2:1.2.3',
             ('tag test-image2:tag2 '
                 'registry.example.com:5000/test-image2:1.2.3-best'),
             'login --username janedoe --password pa55word '
             'registry.example.com:5000',
-            'push registry.example.com:5000/test-image:1.2.3-latest',
+            'push registry.example.com:5000/test-image:1.2.3',
             'push registry.example.com:5000/test-image:1.2.3-best',
-            'push registry.example.com:5000/test-image2:1.2.3-latest',
+            'push registry.example.com:5000/test-image2:1.2.3',
             'push registry.example.com:5000/test-image2:1.2.3-best',
         ])
 

--- a/docker_ci_deploy/tests/test_main.py
+++ b/docker_ci_deploy/tests/test_main.py
@@ -349,7 +349,7 @@ class TestDockerCiDeployRunner(object):
     def test_version_existing_tag(self, capfd):
         """
         When a version is provided and there is an existing tag in the image
-        tag, then the version should be prepende to the tag.
+        tag, then the version should be prepended to the tag.
         """
         runner = DockerCiDeployRunner(executable='echo')
         runner.run(['test-image:abc'], version='1.2.3')
@@ -357,6 +357,22 @@ class TestDockerCiDeployRunner(object):
         assert_output_lines(capfd, [
             'tag test-image:abc test-image:1.2.3-abc',
             'push test-image:1.2.3-abc',
+        ])
+
+    def test_version_existing_tag_multiple_images(self, capfd):
+        """
+        When a version is provided and there is an existing tag in the image
+        tags and multiple tags are provided, then the version should be
+        prepended to each tag.
+        """
+        runner = DockerCiDeployRunner(executable='echo')
+        runner.run(['test-image:abc', 'test-image:def'], version='1.2.3')
+
+        assert_output_lines(capfd, [
+            'tag test-image:abc test-image:1.2.3-abc',
+            'tag test-image:def test-image:1.2.3-def',
+            'push test-image:1.2.3-abc',
+            'push test-image:1.2.3-def',
         ])
 
     def test_version_existing_tag_with_version(self, capfd):


### PR DESCRIPTION
My aim for the API for working with different versions is this:
#### `--tag TAG...`:
Change the tag of the image:
* `test-image:abc` -> `test-image:def`

#### `--tag-version VERSION`:
Prepend the tag with a version:
* `test-image:abc` -> `test-image:1.2.3-abc`

#### `--tag-latest`:
Also tag the image *without* a version, and tag with `latest` if the tag minus the version is empty:
* `test-image:abc` -> `[test-image:1.2.3-abc, test-image:abc]`
* `test-image` -> `[test-image:1.2.3, test-image:latest]`

#### `--tag-semver`:
Tag with all the parts of the version, like some versions of `deploy.py`:
* `test-image:abc` -> `[test-image:1.2.3-abc, test-image:1.2-abc, test-image:1-abc]`

---

The last one hasn't been implemented yet and I'm not 100% sure about the name. The idea is that all these options can be used together and it'll cover all the use cases of `deploy.py`.