### PR TITLE
Add the --semver-precision option to adjust the precision of generated version strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ This will result in the tags `my-image:1.2.3-alpine`, `my-image:1.2-alpine`, and
 
 This works by stripping pieces from the front of the version string using the regex `[.-]?\w+$`. This means that version strings with some text in them are also supported. For example, a tag such as `8.7.1-jessie` will produce the tags/tag prefixes `8.7.1-jessie`, `8.7.1`, `8.7`, and `8`.
 
+An optional "precision" value can be set using the `--semver-precision` option. This sets the minimum precision of the generated versions. For example, by passing `--version 1.2.3 --version-semver --semver-precision 2`, the versions `1.2.3` and `1.2` are generated but *not* `1`.
+
 Note that this will **not** tag a version `0` unless the `--semver-zero` option is also used.
 
 This can be used in combination with `--version-latest`.

--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -160,7 +160,7 @@ def _join_tag_version(tag, version):
     return '-'.join((version, tag))
 
 
-def generate_semver_versions(version, zero=False):
+def generate_semver_versions(version, precision=1, zero=False):
     """
     Generate strings of the given version to different degrees of precision.
     Won't generate a version 0 unless ``zero`` is True.
@@ -168,13 +168,24 @@ def generate_semver_versions(version, zero=False):
          '5.5.0-alpha' => ['5.5.0-alpha', '5.5.0', '5.5', '5']
 
     :param version: The version string to generate versions from.
+    :param precision:
+        The minimum number of version parts in the generated versions.
     :param zero:
         If True, also return the major version '0' when generating versions.
     """
     sub_versions = []
-    while version:
-        sub_versions.append(version)
-        version = re.sub(r'[.-]?\w+$', r'', version)
+    remaining_version = version
+    while remaining_version:
+        sub_versions.append(remaining_version)
+        remaining_version = re.sub(r'[.-]?\w+$', r'', remaining_version)
+
+    if precision > len(sub_versions):
+        raise ValueError(
+            'The minimum precision (%d) is greater than the precision of '
+            "version '%s' (%d)" % (precision, version, len(sub_versions)))
+
+    if precision > 1:
+        sub_versions = sub_versions[:-(precision - 1)]
 
     if not zero and len(sub_versions) > 1 and sub_versions[-1] == '0':
         sub_versions = sub_versions[:-1]

--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -314,6 +314,11 @@ def main(raw_args=sys.argv[1:]):
     parser.add_argument('-S', '--version-semver', action='store_true',
                         help='Combine with --version to also tag the image '
                              'with each major and minor version')
+    parser.add_argument('-P', '--semver-precision', type=int,
+                        metavar='PRECISION',
+                        help='Combine with --version-semver to specify the '
+                             'minimum number of parts in the generated '
+                             'versions (default: 1)')
     parser.add_argument('-Z', '--semver-zero', action='store_true',
                         help='Combine with --version-semver to tag the image '
                              "with the major version '0' when that is part of "
@@ -340,6 +345,8 @@ def main(raw_args=sys.argv[1:]):
     if args.version_semver and not args.version:
         parser.error('the --version-semver option requires --version')
 
+    if args.semver_precision and not args.version_semver:
+        parser.error('the --semver-precision option requires --version-semver')
     if args.semver_zero and not args.version_semver:
         parser.error('the --semver-zero option requires --version-semver')
 
@@ -349,8 +356,11 @@ def main(raw_args=sys.argv[1:]):
     tags = chain.from_iterable(args.tag) if args.tag is not None else None
 
     if args.version:
-        versions = (generate_semver_versions(args.version, args.semver_zero)
-                    if args.version_semver else [args.version])
+        if args.version_semver:
+            versions = generate_semver_versions(
+                args.version, args.semver_precision or 1, args.semver_zero)
+        else:
+            versions = [args.version]
         version_tagger = VersionTagger(versions, args.version_latest)
     else:
         version_tagger = None

--- a/docker_ci_deploy/tests/test_main.py
+++ b/docker_ci_deploy/tests/test_main.py
@@ -149,6 +149,33 @@ class TestGenerateSemverVersionsFunc(object):
         versions = generate_semver_versions('foo')
         assert_that(versions, Equals(['foo']))
 
+    def test_precision_less_than_version(self):
+        """
+        When precision is less than the precision of the version, semantic
+        versions should be generated up to the specified precision.
+        """
+        versions = generate_semver_versions('3.5.3', precision=2)
+        assert_that(versions, Equals(['3.5.3', '3.5']))
+
+    def test_precision_equal_to_version(self):
+        """
+        When precision is equal to the precision of the version, the generated
+        versions should be just the version itself.
+        """
+        versions = generate_semver_versions('3.5.3', precision=3)
+        assert_that(versions, Equals(['3.5.3']))
+
+    def test_precision_greater_than_version(self):
+        """
+        When precision is greater than the precision of the version, an error
+        should be raised.
+        """
+        with ExpectedException(
+            ValueError,
+                r'The minimum precision \(4\) is greater than the precision '
+                r"of version '3\.5\.3' \(3\)"):
+            generate_semver_versions('3.5.3', precision=4)
+
     def test_does_not_generate_zero(self):
         """
         When a version is passed with a major version of 0, the version '0'


### PR DESCRIPTION
Second attempt at #21. Probably best read commit-by-commit.