### PR TITLE
Add basic functionality to tag images with Git information

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ pip install docker-ci-deploy==0.2.0
 
 The script is self-contained and has no dependencies. It can be run by simply executing the [main file](docker-ci-deploy/__main__.py).
 
+**Note:** The script calls the `docker` and `git` binaries on the host for some of its functionality. Those binaries must be present in the process' `PATH` and must be executable by the process' user in order for some functionality to work.
+
 ## Usage
 The script can tag an existing image and push the new tags to a registry.
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ docker-ci-deploy --git-branch --git-hash my-image:latest
 ```
 This will result in the Git branch name and  being used as the image version and. It will produce the tag (for example) `my-image:e35cbc26c63208739b4bc2e9881be2dee5aff50f-develop`, if the most recent commit has hash `e35cbc26c63208739b4bc2e9881be2dee5aff50f` and the current branch is called `develop`.
 
-By default this uses the Git reference `HEAD` to find these values. You can use a different reference via the `--git` option.
-
 There are also the `--hash-latest` and `--hash-short` options which can be combined with `--git-hash`. The former will also tag the image *without* the Git hash (much like `--version-latest`). The latter will result in another tag with the short (7-character) Git hash.
+
+By default this operates in the current working directory and uses the Git reference `HEAD` to find these values. You can use a different working directory and reference via the `--git` option, for example `--git ~/workspace/project:HEAD^1`.
+
+The path to the Git executable used can be configured using `--git-exec`.
 
 #### Custom registry
 ```

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This will result in the Git branch name and  being used as the image version and
 
 There are also the `--hash-latest` and `--hash-short` options which can be combined with `--git-hash`. The former will also tag the image *without* the Git hash (much like `--version-latest`). The latter will result in another tag with the short (7-character) Git hash.
 
-By default this operates in the current working directory and uses the Git reference `HEAD` to find these values. You can use a different working directory and reference via the `--git` option, for example `--git ~/workspace/project:HEAD^1`.
+By default this operates in the current working directory and uses the [Git reference](https://git-scm.com/book/en/v2/Git-Internals-Git-References) `HEAD` to find these values. You can use a different working directory and reference via the `--git` option, for example `--git ~/workspace/project:HEAD^1`.
 
 The path to the Git executable used can be configured using `--git-exec`.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A command-line tool to help generate tags and push Docker images to a registry. 
 In a single command, `docker-ci-deploy` can:
 * Change the tags on images
 * Add version information to image tags
+* Add Git commit/branch information to image tags
 * Add registry addresses to image tags
 * Push tags to a registry
 
@@ -110,6 +111,16 @@ Note that this will **not** tag a version `0` unless the `--semver-zero` option 
 This can be used in combination with `--version-latest`.
 
 > NOTE: The `--version-semver` option used to be known as `--tag-version`. This old option name will continue working for the current release but will be removed soon.
+
+#### Git versioning
+```
+docker-ci-deploy --git-branch --git-hash my-image:latest
+```
+This will result in the Git branch name and  being used as the image version and. It will produce the tag (for example) `my-image:e35cbc26c63208739b4bc2e9881be2dee5aff50f-develop`, if the most recent commit has hash `e35cbc26c63208739b4bc2e9881be2dee5aff50f` and the current branch is called `develop`.
+
+By default this uses the Git reference `HEAD` to find these values. You can use a different reference via the `--git` option.
+
+There are also the `--hash-latest` and `--hash-short` options which can be combined with `--git-hash`. The former will also tag the image *without* the Git hash (much like `--version-latest`). The latter will result in another tag with the short (7-character) Git hash.
 
 #### Custom registry
 ```

--- a/docker_ci_deploy/__main__.py
+++ b/docker_ci_deploy/__main__.py
@@ -390,12 +390,11 @@ def main(raw_args=sys.argv[1:]):
                         help='Combine with --version-semver to tag the image '
                              "with the major version '0' when that is part of "
                              'the version. This is not done by default.')
-    parser.add_argument('-g', '--git', default=None,
+    parser.add_argument('-g', '--git', default=':HEAD',
                         help='Path to the directory that Git should be '
                              'executed in (equivalent to `git -C`) and '
                              'the Git reference to inspect in the form '
-                             '[DIR][:REF] (default: '
-                             '<current working directory>:HEAD)')
+                             '[DIR][:REF] (default: %(default)s)')
     parser.add_argument('-B', '--git-branch', action='store_true',
                         help='Tag the image with the current branch')
     parser.add_argument('-H', '--git-hash', action='store_true',

--- a/docker_ci_deploy/tests/test_main.py
+++ b/docker_ci_deploy/tests/test_main.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
-import os
 import re
 import sys
 from subprocess import CalledProcessError
 
-import pytest
 from testtools import ExpectedException
 from testtools.assertions import assert_that
-from testtools.matchers import (
-    Equals, MatchesListwise, MatchesRegex, MatchesStructure)
+from testtools.matchers import Equals, MatchesRegex, MatchesStructure
 
 from docker_ci_deploy.__main__ import (
     cmd, DockerRunner, GitRunner, join_image_tag, main, RegistryTagger,

--- a/docker_ci_deploy/tests/test_main.py
+++ b/docker_ci_deploy/tests/test_main.py
@@ -600,81 +600,54 @@ class TestDockerRunner(object):
 
 
 class TestGitRunner(object):
-    @pytest.fixture(scope='class')
-    @classmethod
-    def info_script(cls, tmpdir):
-        # FIXME: bit of a hack, and a Unix-specific one at that
-        script = tmpdir.join('info.sh')
-        script.write("""\
-#!/usr/bin/env sh
-echo "args: '$*'"
-echo "pwd: '$(pwd)'"
-""")
-        script.chmod(0o755)
-        return script
-
-    def test_current_branch(self, info_script, capfd):
+    def test_current_branch(self, capfd):
         """
         When the current_branch method is called, Git is called with the
         correct arguments in the context of the current working directory.
         """
-        runner = GitRunner(executable=str(info_script))
+        runner = GitRunner(executable='echo')
         out = runner.current_branch('HEAD')
-        assert_that(out.split('\n'), MatchesListwise([
-            Equals("args: 'rev-parse --abbrev-ref HEAD'"),
-            Equals("pwd: '{}'".format(os.getcwd()))
-        ]))
+        assert_that(out, Equals('rev-parse --abbrev-ref HEAD'))
 
         # Shouldn't be any output to stdout
         assert_output_lines(capfd, [])
 
-    def test_current_hash(self, info_script, capfd):
+    def test_current_hash(self, capfd):
         """
         When the current_hash method is called, Git is called with the
         correct arguments in the context of the current working directory.
         """
-        runner = GitRunner(executable=str(info_script))
+        runner = GitRunner(executable='echo')
         out = runner.current_hash('HEAD')
-        assert_that(out.split('\n'), MatchesListwise([
-            Equals("args: 'rev-parse HEAD'"),
-            Equals("pwd: '{}'".format(os.getcwd()))
-        ]))
+        assert_that(out, Equals('rev-parse HEAD'))
 
         # Shouldn't be any output to stdout
         assert_output_lines(capfd, [])
 
-    def test_current_branch_working_dir(self, info_script, capfd):
+    def test_current_branch_working_dir(self, capfd):
         """
         When the current_branch method is called, and a specific working
         directory is set for the runner, Git is called with the correct
         arguments in the context of the specified working directory.
         """
-        runner = GitRunner(executable=str(info_script),
-                           working_dir=info_script.dirname)
+        runner = GitRunner(executable='echo', working_dir='/foo/bar')
 
         out = runner.current_branch('HEAD')
-        assert_that(out.split('\n'), MatchesListwise([
-            Equals("args: 'rev-parse --abbrev-ref HEAD'"),
-            Equals("pwd: '{}'".format(info_script.dirname))
-        ]))
+        assert_that(out, Equals('-C /foo/bar rev-parse --abbrev-ref HEAD'))
 
         # Shouldn't be any output to stdout
         assert_output_lines(capfd, [])
 
-    def test_current_hash_working_dir(self, info_script, capfd):
+    def test_current_hash_working_dir(self, capfd):
         """
         When the current_hash method is called, and a specific working
         directory is set for the runner, Git is called with the correct
         arguments in the context of the specified working directory.
         """
-        runner = GitRunner(executable=str(info_script),
-                           working_dir=info_script.dirname)
+        runner = GitRunner(executable='echo', working_dir='/foo/bar')
 
         out = runner.current_hash('HEAD')
-        assert_that(out.split('\n'), MatchesListwise([
-            Equals("args: 'rev-parse HEAD'"),
-            Equals("pwd: '{}'".format(info_script.dirname))
-        ]))
+        assert_that(out, Equals('-C /foo/bar rev-parse HEAD'))
 
         # Shouldn't be any output to stdout
         assert_output_lines(capfd, [])


### PR DESCRIPTION
e.g.
```
❯ dcd --dry-run --git-hash --hash-short --hash-latest praekeltfoundation/molo-gem
docker tag praekeltfoundation/molo-gem praekeltfoundation/molo-gem:3c21fbf6aa0e04a743001d9ff99af716f4c58553
docker tag praekeltfoundation/molo-gem praekeltfoundation/molo-gem:3c21fbf
docker tag praekeltfoundation/molo-gem praekeltfoundation/molo-gem:latest
docker push praekeltfoundation/molo-gem:3c21fbf6aa0e04a743001d9ff99af716f4c58553
docker push praekeltfoundation/molo-gem:3c21fbf
docker push praekeltfoundation/molo-gem:latest
```

or...
```
❯ dcd --dry-run --git-branch --git-hash --hash-short --hash-latest praekeltfoundation/seed-message-sender
docker tag praekeltfoundation/seed-message-sender praekeltfoundation/seed-message-sender:e2a7b49ea4c837a7db788262a6ec4811067994a4-develop
docker tag praekeltfoundation/seed-message-sender praekeltfoundation/seed-message-sender:e2a7b49-develop
docker tag praekeltfoundation/seed-message-sender praekeltfoundation/seed-message-sender:develop
docker push praekeltfoundation/seed-message-sender:e2a7b49ea4c837a7db788262a6ec4811067994a4-develop
docker push praekeltfoundation/seed-message-sender:e2a7b49-develop
docker push praekeltfoundation/seed-message-sender:develop
```